### PR TITLE
Added CLI script

### DIFF
--- a/bin/jsmin
+++ b/bin/jsmin
@@ -1,0 +1,76 @@
+#! /usr/bin/env node
+
+var fs = require('fs')
+  , jsmin = require('jsmin').jsmin
+
+var options = {
+  output: true
+, overwrite: false
+, level: null
+, comment: null
+}
+
+var args = Array.prototype.slice.call(process.argv, 2)
+  , filename
+
+out: while (args.length > 0) {
+  var v = args.shift();
+  switch (v) {
+    case '-l':
+    case '--level':
+      options.level = parseInt(args.shift(), 10)
+      break
+    case '-c':
+    case '--comment':
+      options.comment = args.shift()
+      break
+    case '-o':
+    case '--output':
+      options.output = args.shift()
+      break
+    case '--overwrite':
+      options.overwrite = true
+      break
+    default:
+      filename = v
+      break out
+  }
+}
+
+if (filename) {
+  fs.readFile(filename, 'utf8', function(err, text) {
+    if (err) throw err
+    output(jsmin(text, options.level, options.comment))
+  })
+}
+else {
+  var stdin = process.openStdin()
+  stdin.setEncoding('utf8')
+  var text = ''
+  stdin.on('data', function(chunk) {
+    text += chunk
+  })
+  stdin.on('end', function() {
+    output(jsmin(text, options.level, options.comment))
+  })
+}
+
+function output(text) {
+  var out
+  if (options.overwrite && filename) {
+    options.output = filename
+  }
+  if (options.output === true) {
+    out = process.stdout
+  }
+  else {
+    out = fs.createWriteStream(options.output, { flags: 'w'
+                                               , encoding: 'utf8'
+                                               , mode: 0644
+                                               })
+  }
+  out.write(text)
+  if (options.output !== true) {
+    out.end()
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,21 +17,23 @@
            "email": "peteris.krumins@gmail.com",
            "web": "http://www.catonmat.net",
            "twitter": "pkrumins"
-       } 
+       }
    ],
    "licenses": [
        {
            "type": "Doug Crockford's license that allows this module to be used for Good but not for Evil"
-       } 
+       }
    ],
    "repositories": [
        {
            "type": "git",
-           "url": "http://github.com/pkrumins/node-jsmin.git" 
-       } 
+           "url": "http://github.com/pkrumins/node-jsmin.git"
+       }
    ],
    "engines": {
        "node": ">=0.1.93"
+   },
+   "bin" : {
+       "jsmin" : "./bin/jsmin"
    }
 }
-

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,41 @@ Output:
 
     'function hello(a,b,c){sys.log(a+b+c)}'
 
+
+Command-line Usage
+------------------
+
+Installing globally (using npm's -g flag) will also install a command-line
+tool for using jsmin:
+
+    jsmin [OPTIONS...] [FILENAME]
+
+The input filename should be the last argument. If you don't specify it,
+input will be read from STDIN instead.
+
+Supported options:
+
+    -o FILENAME
+    --output FILENAME
+
+        Specifies an output file for minified output. If not given, output
+        will be written to STDOUT.
+
+    -l LEVEL
+    --level LEVEL
+
+        Sets the aggressiveness level to be used.
+
+    -c COMMENT
+    --comment COMMENT
+
+        Sets a comment to be prepended to the output.
+
+    --overwrite
+
+        If provided and an input filename was provided (rather than using
+        STDIN), output will be written to the same file input was read from.
+
 ------------------------------------------------------------------------------
 
 Have fun jsminning!


### PR DESCRIPTION
I've added a basic CLI script for using jsmin from the command-line, which is pretty much a direct lift from what [UglifyJS](https://github.com/mishoo/UglifyJS) does.

I was only looking for a handy way to run jsmin and write to stdout so I could do this in one go without faffing about with temporary files...

```
jsmin yourlib.js | gzip -9f | wc
```

...but I've also added command-line options for file output and for the arguments the `jsmin` function supports.
